### PR TITLE
feat: Common Response 구축 및 GlobalExceptionHandler 구축

### DIFF
--- a/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/CustomException.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/CustomException.java
@@ -1,0 +1,12 @@
+package online.palworldkorea.palworldkorea_online.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/ErrorCode.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/ErrorCode.java
@@ -1,0 +1,25 @@
+package online.palworldkorea.palworldkorea_online.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    ALREADY_EXISTS_EMAIL_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
+    ALREADY_EXISTS_NICKNAME_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
+    BINDING_EXCEPTION(HttpStatus.BAD_REQUEST, "Binding Exception"),
+    EMAIL_NOT_FOUND_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 이메일입니다."),
+    INVALID_PASSWORD_EXCEPTION(HttpStatus.BAD_REQUEST, "비밀번호가 올바르지 않습니다."),
+    INVALID_REFRESH_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 Refresh Token 입니다."),
+    INVALID_ACCESS_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 Access Token 입니다."),
+    INVALID_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 Token 정보 입니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package online.palworldkorea.palworldkorea_online.global.exception;
+
+import online.palworldkorea.palworldkorea_online.global.response.CommonResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Objects;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(CustomException.class)
+    public CommonResponse<?> handleCustomException(CustomException e) {
+        return CommonResponse.error(e.getErrorCode());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public CommonResponse<?> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        String errorMessage = Objects.requireNonNull(e.getBindingResult().getFieldError()).toString();
+
+        return CommonResponse.error((HttpStatus) e.getStatusCode(), errorMessage);
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/custom_exception/AlreadyExistsEmailException.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/custom_exception/AlreadyExistsEmailException.java
@@ -1,0 +1,10 @@
+package online.palworldkorea.palworldkorea_online.global.exception.custom_exception;
+
+import online.palworldkorea.palworldkorea_online.global.exception.CustomException;
+import online.palworldkorea.palworldkorea_online.global.exception.ErrorCode;
+
+public class AlreadyExistsEmailException extends CustomException {
+    public AlreadyExistsEmailException() {
+        super(ErrorCode.ALREADY_EXISTS_EMAIL_EXCEPTION);
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/custom_exception/AlreadyExistsNicknameException.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/custom_exception/AlreadyExistsNicknameException.java
@@ -1,0 +1,10 @@
+package online.palworldkorea.palworldkorea_online.global.exception.custom_exception;
+
+import online.palworldkorea.palworldkorea_online.global.exception.CustomException;
+import online.palworldkorea.palworldkorea_online.global.exception.ErrorCode;
+
+public class AlreadyExistsNicknameException extends CustomException {
+    public AlreadyExistsNicknameException() {
+        super(ErrorCode.ALREADY_EXISTS_NICKNAME_EXCEPTION);
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/custom_exception/EmailNotFoundException.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/custom_exception/EmailNotFoundException.java
@@ -1,0 +1,10 @@
+package online.palworldkorea.palworldkorea_online.global.exception.custom_exception;
+
+import online.palworldkorea.palworldkorea_online.global.exception.CustomException;
+import online.palworldkorea.palworldkorea_online.global.exception.ErrorCode;
+
+public class EmailNotFoundException extends CustomException {
+    public EmailNotFoundException() {
+        super(ErrorCode.EMAIL_NOT_FOUND_EXCEPTION);
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/custom_exception/InvalidAccessTokenException.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/custom_exception/InvalidAccessTokenException.java
@@ -1,0 +1,10 @@
+package online.palworldkorea.palworldkorea_online.global.exception.custom_exception;
+
+import online.palworldkorea.palworldkorea_online.global.exception.CustomException;
+import online.palworldkorea.palworldkorea_online.global.exception.ErrorCode;
+
+public class InvalidAccessTokenException extends CustomException {
+    public InvalidAccessTokenException() {
+        super(ErrorCode.INVALID_ACCESS_TOKEN_EXCEPTION);
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/custom_exception/InvalidPasswordException.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/custom_exception/InvalidPasswordException.java
@@ -1,0 +1,11 @@
+package online.palworldkorea.palworldkorea_online.global.exception.custom_exception;
+
+import online.palworldkorea.palworldkorea_online.global.exception.CustomException;
+import online.palworldkorea.palworldkorea_online.global.exception.ErrorCode;
+
+public class InvalidPasswordException extends CustomException {
+
+    public InvalidPasswordException() {
+        super(ErrorCode.INVALID_PASSWORD_EXCEPTION);
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/custom_exception/InvalidRefreshTokenException.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/custom_exception/InvalidRefreshTokenException.java
@@ -1,0 +1,10 @@
+package online.palworldkorea.palworldkorea_online.global.exception.custom_exception;
+
+import online.palworldkorea.palworldkorea_online.global.exception.CustomException;
+import online.palworldkorea.palworldkorea_online.global.exception.ErrorCode;
+
+public class InvalidRefreshTokenException extends CustomException {
+    public InvalidRefreshTokenException() {
+        super(ErrorCode.INVALID_REFRESH_TOKEN_EXCEPTION);
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/custom_exception/InvalidTokenException.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/custom_exception/InvalidTokenException.java
@@ -1,0 +1,10 @@
+package online.palworldkorea.palworldkorea_online.global.exception.custom_exception;
+
+import online.palworldkorea.palworldkorea_online.global.exception.CustomException;
+import online.palworldkorea.palworldkorea_online.global.exception.ErrorCode;
+
+public class InvalidTokenException extends CustomException {
+    public InvalidTokenException() {
+        super(ErrorCode.INVALID_TOKEN_EXCEPTION);
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/global/response/CommonResponse.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/global/response/CommonResponse.java
@@ -1,0 +1,26 @@
+package online.palworldkorea.palworldkorea_online.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import online.palworldkorea.palworldkorea_online.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public class CommonResponse<T> {
+    private HttpStatus httpStatus;
+    private String message;
+    private T data;
+
+    public static <T> CommonResponse<T> success(SuccessCode successCode, T data) {
+        return new CommonResponse<>(successCode.getHttpStatus(), successCode.getReasonPhrase(), data);
+    }
+
+    public static CommonResponse<?> error(ErrorCode errorCode) {
+        return new CommonResponse<>(errorCode.getStatus(), errorCode.getMessage(), null);
+    }
+
+    public static CommonResponse<?> error(HttpStatus httpStatus, String message) {
+        return new CommonResponse<>(httpStatus, message, null);
+    }
+}


### PR DESCRIPTION
### :rocket: Pull Request

#### :page_facing_up: 작업 목록
- Common Response 구축
- GlobalExceptionHandler 구축

#### :warning: 주의사항
1. ErrorCode 지속 추가
2. CustomException의 경우 CustomException을 상속 받도록 구현 -> GlobalExceptionHandler에서 CustomException을 catch
3. @Valid 어노테이션에서 발생하는 MethodArgumentNotValidException은 개별 메서드로 추가

#### :camera: API 설계
1. 모든 Controller의 API에서 아래와 같은 형태의 CommonResponse를 반환하도록 구현 필요
```java
        return CommonResponse.success(SuccessCode.REGISTER_MEMBER_SUCCESS, memberService.register(memberRegisterReguestDto));
```

#### :bulb: 테스트
1. 

#### :mag: 관련 이슈
resolved: #4

#### :memo: 기타 정보
