### PR TITLE
feat: JWT 사용을 위한 기본적인 설정

### DIFF
--- a/src/main/java/online/palworldkorea/palworldkorea_online/authentication/controller/AuthenticationController.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/authentication/controller/AuthenticationController.java
@@ -1,0 +1,28 @@
+package online.palworldkorea.palworldkorea_online.authentication.controller;
+
+import lombok.RequiredArgsConstructor;
+import online.palworldkorea.palworldkorea_online.authentication.service.AuthenticationService;
+import online.palworldkorea.palworldkorea_online.global.response.SuccessCode;
+import online.palworldkorea.palworldkorea_online.global.response.CommonResponse;
+import online.palworldkorea.palworldkorea_online.member.dto.MemberDto;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthenticationController {
+    private final AuthenticationService authenticationService;
+
+    @PostMapping("/login")
+    public CommonResponse<?> login(@RequestBody MemberDto.LoginRequest memberRegisterReguestDto) {
+        return CommonResponse.success(SuccessCode.LOGIN_SUCCESS, authenticationService.login(memberRegisterReguestDto));
+    }
+
+    @PostMapping("/refresh-token")
+    public CommonResponse<?> refreshAccessToken(@RequestBody String refreshToken) {
+        return CommonResponse.success(SuccessCode.REFRESH_ACCESS_TOKEN_SUCCESS, authenticationService.refreshAccessToken(refreshToken));
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/authentication/dto/TokenDto.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/authentication/dto/TokenDto.java
@@ -1,0 +1,11 @@
+package online.palworldkorea.palworldkorea_online.authentication.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TokenDto {
+    private final String refreshToken;
+    private final String accessToken;
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/authentication/service/AuthenticationService.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/authentication/service/AuthenticationService.java
@@ -1,0 +1,48 @@
+package online.palworldkorea.palworldkorea_online.authentication.service;
+
+import lombok.RequiredArgsConstructor;
+import online.palworldkorea.palworldkorea_online.authentication.dto.TokenDto;
+import online.palworldkorea.palworldkorea_online.global.exception.custom_exception.InvalidPasswordException;
+import online.palworldkorea.palworldkorea_online.global.jwt.JwtTokenUtil;
+import online.palworldkorea.palworldkorea_online.member.dto.MemberDto;
+import online.palworldkorea.palworldkorea_online.member.entity.Member;
+import online.palworldkorea.palworldkorea_online.member.service.MemberService;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AuthenticationService {
+    private final MemberService memberService;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenUtil jwtTokenUtil;
+
+    public MemberDto.Response login(MemberDto.LoginRequest memberLoginRequestDto) {
+        Member member = memberService.getMember(memberLoginRequestDto.getEmail());
+
+        checkPassword(memberLoginRequestDto, member);
+
+        TokenDto tokenDto = new TokenDto(
+                jwtTokenUtil.generateRefreshToken(member.getEmail(), member.getAuthorities()),
+                jwtTokenUtil.generateAccessToken(member.getEmail(), member.getAuthorities())
+        );
+
+        return MemberDto.Response.fromEntity(member, tokenDto);
+    }
+
+    public TokenDto refreshAccessToken(String refreshToken) {
+        jwtTokenUtil.validateToken(refreshToken);
+
+        String email = jwtTokenUtil.getEmailFromToken(refreshToken);
+        List<GrantedAuthority> authorities = jwtTokenUtil.getAuthoritiesFromToken(refreshToken);
+        return new TokenDto(null, jwtTokenUtil.generateAccessToken(email, authorities));
+    }
+
+    private void checkPassword(MemberDto.LoginRequest memberLoginRequestDto, Member member) {
+        if (!member.checkInputPasswordIsCorrect(memberLoginRequestDto.getPassword(), passwordEncoder))
+            throw new InvalidPasswordException();
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/config/SecurityConfig.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/config/SecurityConfig.java
@@ -1,26 +1,38 @@
 package online.palworldkorea.palworldkorea_online.config;
 
+import lombok.RequiredArgsConstructor;
+import online.palworldkorea.palworldkorea_online.global.jwt.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorizeRequests ->
                         authorizeRequests
-                                .requestMatchers("/**").permitAll()
+                                .requestMatchers("/auth/login", "/auth/refresh-token", "/members").permitAll()
                                 .anyRequest().authenticated()
                 )
-                .formLogin(formLogin -> formLogin.loginPage("/login").permitAll())
-                .logout(logout -> logout.logoutUrl("/logout"));
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+        ;
 
         return http.build();
     }

--- a/src/main/java/online/palworldkorea/palworldkorea_online/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,59 @@
+package online.palworldkorea.palworldkorea_online.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import online.palworldkorea.palworldkorea_online.global.exception.custom_exception.InvalidAccessTokenException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtTokenUtil jwtTokenUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if (request.getHeader("Authorization") != null) {
+            String token = getJwtFromRequest(request);
+
+            jwtTokenUtil.validateToken(token);
+
+            String email = jwtTokenUtil.getEmailFromToken(token);
+            List<GrantedAuthority> authorities = jwtTokenUtil.getAuthoritiesFromToken(token);
+            UsernamePasswordAuthenticationToken authenticationToken = getAuthenticationToken(email, authorities);
+
+            WebAuthenticationDetails details = new WebAuthenticationDetails(request);
+            authenticationToken.setDetails(details);
+
+            SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer "))
+            return bearerToken.substring(7);
+
+        throw new InvalidAccessTokenException();
+    }
+
+    private UsernamePasswordAuthenticationToken getAuthenticationToken(String email, List<GrantedAuthority> authorities) {
+        return new UsernamePasswordAuthenticationToken(
+                email,
+                null,
+                authorities
+        );
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/global/jwt/JwtTokenUtil.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/global/jwt/JwtTokenUtil.java
@@ -1,0 +1,92 @@
+package online.palworldkorea.palworldkorea_online.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import online.palworldkorea.palworldkorea_online.global.exception.custom_exception.InvalidTokenException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.security.Key;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+@Component
+public class JwtTokenUtil {
+    @Value("${jwt.secretKey}")
+    private String secretKey;
+
+    @Value("${jwt.accessTokenExpirationTime}")
+    private long accessTokenExpirationTime;
+
+    @Value("${jwt.refreshTokenExpirationTime}")
+    private long refreshTokenExpirationTime;
+
+    public String generateAccessToken(String email, List<GrantedAuthority> authorities) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + accessTokenExpirationTime);
+        Key key = getKey();
+
+        return generateNewToken(now, email, authorities, expiration, key);
+    }
+
+    public String generateRefreshToken(String email, List<GrantedAuthority> authorities) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + refreshTokenExpirationTime);
+
+        Key key = getKey();
+
+        return generateNewToken(now, email, authorities, expiration, key);
+    }
+
+    public boolean validateToken(String token) {
+        SecretKey key = getKey();
+
+        Date expiration = getPayload(key, token).getExpiration();
+        if (expiration.before(new Date()))
+            throw new InvalidTokenException();
+
+        return true;
+    }
+
+    public String getEmailFromToken(String token) {
+        SecretKey key = getKey();
+
+        return getPayload(key, token).getSubject();
+    }
+
+    public List<GrantedAuthority> getAuthoritiesFromToken(String token) {
+        SecretKey key = getKey();
+
+        return getPayload(key, token).get("authorities", List.class);
+    }
+
+    private SecretKey getKey() {
+        return Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+
+    private String generateNewToken(Date now, String email, List<GrantedAuthority> authorities, Date expiration, Key key) {
+        return Jwts.builder()
+                .issuedAt(now)
+                .subject(email)
+                .claim("authorities", authorities)
+                .expiration(expiration)
+                .signWith(key)
+                .compact();
+    }
+
+    private Claims getPayload(SecretKey key, String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (Exception e) {
+            throw new InvalidTokenException();
+        }
+    }
+}

--- a/src/test/java/online/palworldkorea/palworldkorea_online/global/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/online/palworldkorea/palworldkorea_online/global/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,49 @@
+package online.palworldkorea.palworldkorea_online.global.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import online.palworldkorea.palworldkorea_online.member.entity.MemberRole;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JwtAuthenticationFilterTest {
+    private MockMvc mockMvc;
+
+    @Mock
+    private JwtTokenUtil jwtTokenUtil;
+
+    @InjectMocks
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        mockMvc = MockMvcBuilders.standaloneSetup(jwtAuthenticationFilter).build();
+    }
+
+    @Test
+    void shoudSetAuthenticationInSecurityContext_whenTokenIsValid() throws Exception {
+        // given
+        String validToken = "valid.jwt.token";
+        String email = "valid@example.com";
+        WebAuthenticationDetails details = new WebAuthenticationDetails(mock(HttpServletRequest.class));
+
+        // when
+
+        // then
+        Assertions.assertThat(jwtTokenUtil.getEmailFromToken(validToken)).isEqualTo(email);
+        Assertions.assertThat(jwtTokenUtil.getAuthoritiesFromToken(validToken)).isEqualTo(List.of(MemberRole.USER_LEVEL0));
+     }
+}


### PR DESCRIPTION
### :rocket: Pull Request

#### :page_facing_up: 작업 목록
- JwtAuthenticationFilter 구현
- JwtTokenUtil 구현
- AuthenticationController 구현
- AuthenticationService 구현

#### :warning: 주의사항
1. Spring Security를 통한 권한 별 uri 분리 필요

#### :camera: API 설계
1. JwtAuthenticationFilter 에서 Header의 Authentication 정보가 있을 때 Token에 저장된 인증 정보를 SecurityContextHolder에 저장

2. AuthenticationController에서 로그인 시, 새로운 refresh-token과 access-token 발급
3. access-token 만료 시, /refresh-token 을 통해 access-token 재발급 가능 (refresh-token 만료 시, 재로그인 필요)


#### :bulb: 테스트
1. 추후 구축

#### :mag: 관련 이슈
resolved: #6

#### :memo: 기타 정보
필요 시, token 블랙리스트 기능 구현
