### PR TITLE
feat: 사용자 관련 API 구현

### DIFF
--- a/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/ErrorCode.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/ErrorCode.java
@@ -13,7 +13,7 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 Refresh Token 입니다."),
     INVALID_ACCESS_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 Access Token 입니다."),
     INVALID_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 Token 정보 입니다."),
-    ;
+    INVALID_MEMBER_ID_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 유저 고유 번호(id) 입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/custom_exception/InvalidMemberIdException.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/global/exception/custom_exception/InvalidMemberIdException.java
@@ -1,0 +1,10 @@
+package online.palworldkorea.palworldkorea_online.global.exception.custom_exception;
+
+import online.palworldkorea.palworldkorea_online.global.exception.CustomException;
+import online.palworldkorea.palworldkorea_online.global.exception.ErrorCode;
+
+public class InvalidMemberIdException extends CustomException {
+    public InvalidMemberIdException() {
+        super(ErrorCode.INVALID_MEMBER_ID_EXCEPTION);
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/global/response/SuccessCode.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/global/response/SuccessCode.java
@@ -1,0 +1,25 @@
+package online.palworldkorea.palworldkorea_online.global.response;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum SuccessCode {
+    REGISTER_MEMBER_SUCCESS(HttpStatus.CREATED, "회원 가입에 성공했습니다."),
+    DELETE_MEMBER_SUCCESS(HttpStatus.ACCEPTED, "회원 탈퇴가 완료되었습니다."),
+    LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다."),
+    REFRESH_ACCESS_TOKEN_SUCCESS(HttpStatus.CREATED, "ACCESS TOKEN 재발급에 성공했습니다."),
+    GET_BOARD_SUCCESS(HttpStatus.OK, "게시판 조회에 성공했습니다."),
+    POST_BOARD_SUCCESS(HttpStatus.CREATED, "게시판 등록에 성공했습니다."),
+    UPDATE_BOARD_SUCCESS(HttpStatus.ACCEPTED, "게시판 수정에 성공했습니다."),
+    DELETE_BOARD_SUCCESS(HttpStatus.ACCEPTED, "게시판 삭제에 성공했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String reasonPhrase;
+
+    SuccessCode(HttpStatus httpStatus, String reasonPhrase) {
+        this.httpStatus = httpStatus;
+        this.reasonPhrase = reasonPhrase;
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/global/util/MemberUtil.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/global/util/MemberUtil.java
@@ -1,0 +1,11 @@
+package online.palworldkorea.palworldkorea_online.global.util;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class MemberUtil {
+    private MemberUtil() {}
+
+    public static String getEmail() {
+        return SecurityContextHolder.getContext().getAuthentication().getName();
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/member/controller/MemberController.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/member/controller/MemberController.java
@@ -1,0 +1,27 @@
+package online.palworldkorea.palworldkorea_online.member.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import online.palworldkorea.palworldkorea_online.global.response.SuccessCode;
+import online.palworldkorea.palworldkorea_online.global.response.CommonResponse;
+import online.palworldkorea.palworldkorea_online.member.dto.MemberDto;
+import online.palworldkorea.palworldkorea_online.member.service.MemberService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController {
+    private final MemberService memberService;
+
+    @PostMapping
+    public CommonResponse<?> signUp(@RequestBody @Valid MemberDto.RegisterReguest memberRegisterReguestDto) {
+        return CommonResponse.success(SuccessCode.REGISTER_MEMBER_SUCCESS, memberService.signUp(memberRegisterReguestDto));
+    }
+
+    @DeleteMapping("/{id}")
+    public CommonResponse<?> deleteMember(@PathVariable long id) {
+
+        return CommonResponse.success(SuccessCode.DELETE_MEMBER_SUCCESS, memberService.deleteMember(id));
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/member/dto/MemberDto.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/member/dto/MemberDto.java
@@ -1,0 +1,74 @@
+package online.palworldkorea.palworldkorea_online.member.dto;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.*;
+import online.palworldkorea.palworldkorea_online.authentication.dto.TokenDto;
+import online.palworldkorea.palworldkorea_online.member.entity.Member;
+import online.palworldkorea.palworldkorea_online.member.entity.MemberRole;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class MemberDto {
+    private MemberDto() {}
+
+    @Getter
+    @Setter
+    public static class RegisterReguest {
+        @Pattern(regexp = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$", message = "올바른 이메일 형식이 아닙니다.")
+        private String email;
+
+        @Pattern(regexp = "^(?=.*[!@#$%^&*()_+\\-={}|\\[\\]:'\";<>?,./]).{8,16}$", message = "비밀번호는 8자 이상 16자 이하, 특수문자를 포함해야 합니다.")
+        private String password;
+
+        @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9-_]{2,10}$", message = "닉네임은 특수문자를 제외한 2~10자리여야 합니다.")
+        private String nickname;
+
+        private MemberRole memberRole = MemberRole.USER_LEVEL0;
+
+        public Member toEntity(PasswordEncoder passwordEncoder) {
+            return new Member(email, getEncodedPassword(passwordEncoder), nickname, memberRole);
+        }
+
+        private String getEncodedPassword(PasswordEncoder passwordEncoder) {
+            return passwordEncoder.encode(password);
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class LoginRequest {
+        @Pattern(regexp = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$", message = "올바른 이메일 형식이 아닙니다.")
+        private String email;
+
+        @Pattern(regexp = "^(?=.*[!@#$%^&*()_+\\-={}|\\[\\]:'\";<>?,./]).{8,16}$", message = "비밀번호는 8자 이상 16자 이하, 특수문자를 포함해야 합니다.")
+        private String password;
+    }
+
+    @Builder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Response {
+        private String email;
+        private String nickname;
+        private MemberRole memberRole;
+        private TokenDto token;
+
+        public static Response fromEntity(Member member) {
+            return Response.builder()
+                    .email(member.getEmail())
+                    .nickname(member.getNickname())
+                    .memberRole(member.getMemberRole())
+                    .build();
+        }
+
+        public static Response fromEntity(Member member, TokenDto tokenDto) {
+            return Response.builder()
+                    .email(member.getEmail())
+                    .nickname(member.getNickname())
+                    .memberRole(member.getMemberRole())
+                    .token(tokenDto)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/member/entity/Member.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/member/entity/Member.java
@@ -1,0 +1,63 @@
+package online.palworldkorea.palworldkorea_online.member.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@SQLDelete(sql = "UPDATE member SET is_deleted = true where id = ?")
+@SQLRestriction("is_deleted is False")
+public class Member implements UserDetails {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private String email;
+
+    private String password;
+
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    private MemberRole memberRole;
+
+    private boolean isDeleted;
+
+    public Member(String email, String password, String nickname, MemberRole memberRole) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.memberRole = memberRole;
+    }
+
+    @Override
+    public List<GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(memberRole.name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    public boolean checkInputPasswordIsCorrect(String inputPassword, PasswordEncoder passwordEncoder) {
+        String encodedInputPassword = passwordEncoder.encode(inputPassword);
+
+        return encodedInputPassword.equals(this.password);
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/member/entity/MemberRole.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/member/entity/MemberRole.java
@@ -1,0 +1,12 @@
+package online.palworldkorea.palworldkorea_online.member.entity;
+
+import org.springframework.security.core.GrantedAuthority;
+
+public enum MemberRole implements GrantedAuthority {
+    USER_LEVEL0, USER_LEVEL1, USER_LEVEL2, USER_LEVEL3, ADMIN;
+
+    @Override
+    public String getAuthority() {
+        return this.name();
+    }
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/member/repository/MemberRepository.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/member/repository/MemberRepository.java
@@ -1,0 +1,14 @@
+package online.palworldkorea.palworldkorea_online.member.repository;
+
+import online.palworldkorea.palworldkorea_online.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByNickname(String nickname);
+}

--- a/src/main/java/online/palworldkorea/palworldkorea_online/member/service/MemberService.java
+++ b/src/main/java/online/palworldkorea/palworldkorea_online/member/service/MemberService.java
@@ -1,0 +1,65 @@
+package online.palworldkorea.palworldkorea_online.member.service;
+
+import lombok.RequiredArgsConstructor;
+import online.palworldkorea.palworldkorea_online.global.exception.custom_exception.AlreadyExistsEmailException;
+import online.palworldkorea.palworldkorea_online.global.exception.custom_exception.AlreadyExistsNicknameException;
+import online.palworldkorea.palworldkorea_online.global.exception.custom_exception.EmailNotFoundException;
+import online.palworldkorea.palworldkorea_online.global.exception.custom_exception.InvalidMemberIdException;
+import online.palworldkorea.palworldkorea_online.member.dto.MemberDto;
+import online.palworldkorea.palworldkorea_online.member.entity.Member;
+import online.palworldkorea.palworldkorea_online.member.repository.MemberRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberService {
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public MemberDto.Response signUp(MemberDto.RegisterReguest memberRegisterReguestDto) {
+        checkIsEmailAlreadySignedUp(memberRegisterReguestDto.getEmail());
+
+        validateNickname(memberRegisterReguestDto.getNickname());
+
+        Member member = memberRegisterReguestDto.toEntity(passwordEncoder);
+
+        memberRepository.save(member);
+
+        return MemberDto.Response.fromEntity(member);
+    }
+
+    public MemberDto.Response deleteMember(long id) {
+        Member member = getMemberById(id);
+
+        memberRepository.delete(member);
+
+        return MemberDto.Response.fromEntity(member);
+    }
+
+    private Member getMemberById(long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(InvalidMemberIdException::new);
+    }
+
+    public Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(EmailNotFoundException::new);
+    }
+
+    public void checkIsEmailAlreadySignedUp(String email) {
+        if (memberRepository.findByEmail(email)
+                .isPresent()) {
+            throw new AlreadyExistsEmailException();
+        }
+    }
+
+    private void validateNickname(String nickname) {
+        if (memberRepository.findByNickname(nickname)
+                .isPresent()) {
+            throw new AlreadyExistsNicknameException();
+        }
+    }
+}


### PR DESCRIPTION
### :rocket: Pull Request

#### :page_facing_up: 작업 목록
- Member Entity 생성
- Member Role 구분
- 회원가입 API
- 로그인 API
- 회원 탈퇴 API
- MemberUtil을 통해 토큰을 통해 email 정보를 받아올 수 있도록 구현
- Member 삭제 시, db에서 직접 삭제를 하는게 아닌 isDeleted=true로 바꾸도록 구현

#### :warning: 주의사항
1. 테스트 코드 필요

#### :camera: API 설계
1. 회원가입
```java
    public MemberDto.Response signUp(MemberDto.RegisterReguest memberRegisterReguestDto) {
        checkIsEmailAlreadySignedUp(memberRegisterReguestDto.getEmail());

        validateNickname(memberRegisterReguestDto.getNickname());

        Member member = memberRegisterReguestDto.toEntity(passwordEncoder);

        memberRepository.save(member);

        return MemberDto.Response.fromEntity(member);
    }
```
이메일과 닉네임이 중복되지 않도록 구현

2. 로그인
```java
    public MemberDto.Response login(MemberDto.LoginRequest memberLoginRequestDto) {
        Member member = memberService.getMemberByEmail(memberLoginRequestDto.getEmail());

        checkPassword(memberLoginRequestDto, member);

        TokenDto tokenDto = new TokenDto(
                jwtTokenUtil.generateRefreshToken(member.getEmail(), member.getAuthorities()),
                jwtTokenUtil.generateAccessToken(member.getEmail(), member.getAuthorities())
        );

        return MemberDto.Response.fromEntity(member, tokenDto);
    }
```
로그인 시, 비밀번호 확인 후 새로운 AccessToken과 RefreshToken을 발급하도록 구현

3. 회원 탈퇴
```java
@Entity
@Getter
@NoArgsConstructor
@SQLDelete(sql = "UPDATE member SET is_deleted = true where id = ?")
@SQLRestriction("is_deleted is False")
public class Member implements UserDetails {
```
@SQLDelete와 @SQLRestriction을 활용하여 회원 탈퇴 시, isDeleted 필드를 True로 변경하도록 구현 

#### :bulb: 테스트
1. 구현 필요

#### :mag: 관련 이슈
resolved: 3

#### :memo: 기타 정보
